### PR TITLE
Add Non AI Lab Sample App

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 ## Usage in AI-lab templates
 
-This repository is being used in [ai-lab-template](https://github.com/redhat-ai-dev/ai-lab-template) as component source code for user to start with. 
+This repository is being used in [ai-lab-template](https://github.com/redhat-ai-dev/ai-lab-template) and [ai-lab-template-experiment](https://github.com/redhat-ai-dev/ai-lab-template-experiment) as component source code for users to start with. 
 
-This is a copy of the ai lab sample apps source code. The master copy of those apps are under [ai-lab-recipes](https://github.com/containers/ai-lab-recipes)
+Most sample apps in this repository are copies of the ai lab sample apps source code. The master copy of these apps are under [ai-lab-recipes](https://github.com/containers/ai-lab-recipes)
 
-To pull in the latest changes, run `./pull-sample-app.sh`, and commit the changes.
+To pull in the latest changes for the ai lab sample apps, run `./pull-sample-app.sh`, and commit the changes.

--- a/non-ai-lab-chatbot/Containerfile
+++ b/non-ai-lab-chatbot/Containerfile
@@ -1,0 +1,10 @@
+FROM registry.access.redhat.com/ubi9/python-311:1-62.1716478620
+WORKDIR /app
+COPY requirements.txt .
+RUN pip install --upgrade pip
+RUN pip install --no-cache-dir --upgrade -r /app/requirements.txt
+COPY src/sample-app.py .
+ENV GRADIO_SERVER_NAME="0.0.0.0"
+EXPOSE 8501
+USER root
+ENTRYPOINT [ "python", "sample-app.py" ]

--- a/non-ai-lab-chatbot/README.md
+++ b/non-ai-lab-chatbot/README.md
@@ -1,0 +1,3 @@
+## Sample Application
+
+This is a sample application for testing local Podman Desktop deployment without using an AI Lab Recipe.

--- a/non-ai-lab-chatbot/requirements.txt
+++ b/non-ai-lab-chatbot/requirements.txt
@@ -1,0 +1,4 @@
+langchain==0.2.7
+langchain-openai==0.1.16
+langchain-community==0.2.4
+gradio==4.38.1

--- a/non-ai-lab-chatbot/src/sample-app.py
+++ b/non-ai-lab-chatbot/src/sample-app.py
@@ -1,0 +1,65 @@
+import os
+import requests
+import time
+
+import gradio as gr
+from langchain_openai import ChatOpenAI
+from langchain.chains import LLMChain
+from langchain_core.prompts import PromptTemplate
+
+
+model_endpoint = os.getenv("MODEL_ENDPOINT", "http://localhost:8001")
+model_service = f"{model_endpoint}/v1"
+
+def checking_model_service():
+    start = time.time()
+    print("Checking Model Service Availability...")
+    ready = False
+    while not ready:
+        try:
+            request = requests.get(f'{model_service}/models')
+            if request.status_code == 200:
+                ready = True
+        except:
+            pass
+        time.sleep(1) 
+    print("Model Service Available")
+    print(f"{time.time()-start} seconds")
+
+checking_model_service()
+model_name = os.getenv("MODEL_NAME", "")
+
+llm = ChatOpenAI(base_url=model_service,
+                 model=model_name,
+                 api_key="no-key",
+                 )
+
+template = """You are the best advisor in the world.
+
+A user has come to you and asks the following question:
+{message}
+
+If you need to ask clarifying questions you may do so.
+"""
+prompt = PromptTemplate.from_template(template)
+
+chain = prompt | llm
+
+def handle_response(message, history):
+    result = chain.invoke({
+            "message": message
+        }
+    )
+    output_resp = ""
+    for char in result.content:
+        output_resp += char
+        time.sleep(0.03)
+        yield output_resp
+
+
+chatbot = gr.ChatInterface(
+                fn=handle_response,
+                title="Sample Chatbot",
+)
+
+chatbot.launch(server_port=8501)


### PR DESCRIPTION
This pulls in the sample app I created that was not initially created by AI Lab so that we can deploy an app locally with Podman without it being already present in the extension.

Also updates the main readme to be more clear as there is now non ai lab samples in the repo.